### PR TITLE
add --with-pjproject-bundled configure flag to enable pjsip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN	set -x \
 	&& cd /usr/local/src/asterisk \
 	&& yes | contrib/scripts/install_prereq install \
 	&& contrib/scripts/install_prereq test \
-	&& ./bootstrap.sh && ./configure \
+	&& ./bootstrap.sh && ./configure --with-pjproject-bundled \
 	&& make menuselect.makeopts \
 	&& menuselect/menuselect --disable BUILD_NATIVE --disable-all \
 		--enable chan_bridge_media \


### PR DESCRIPTION
Asterisk versions lower than 15 need the --with-pjproject-bundled flag to actually make it compile with the pjsip modules.

Reference:
[https://wiki.asterisk.org/wiki/display/AST/PJSIP-pjproject](https://wiki.asterisk.org/wiki/display/AST/PJSIP-pjproject)